### PR TITLE
make CGRect.center internal access level

### DIFF
--- a/MaLiang/Classes/Math & Utils/Utils.swift
+++ b/MaLiang/Classes/Math & Utils/Utils.swift
@@ -59,7 +59,7 @@ extension CGSize {
     }
 }
 
-public extension CGRect {
+extension CGRect {
     var center: CGPoint {
         return CGPoint(x: origin.x + width / 2, y: origin.y + height / 2)
     }


### PR DESCRIPTION
The exposure of this property may result in name conflicts with other libraries.
