### PR TITLE
Change init sequence for MTLTexture pixel format.

### DIFF
--- a/MaLiang/Classes/MetalBase/RenderTarget.swift
+++ b/MaLiang/Classes/MetalBase/RenderTarget.swift
@@ -37,10 +37,10 @@ open class RenderTarget {
     public init(size: CGSize, pixelFormat: MTLPixelFormat, device: MTLDevice?) {
         
         self.drawableSize = size
+        self.pixelFormat = pixelFormat
         self.device = device
         self.texture = makeEmptyTexture()
         self.commandQueue = device?.makeCommandQueue()
-        self.pixelFormat = pixelFormat
         
         renderPassDescriptor = MTLRenderPassDescriptor()
         let attachment = renderPassDescriptor?.colorAttachments[0]


### PR DESCRIPTION
Inside of makeEmptyTexture function, there is using pixelFormat for making texture.
So I think sequence should be changed.